### PR TITLE
Append paragraphs after each "sentence.translated" element

### DIFF
--- a/WebNovelConverter/Sources/Websites/LNMTLSource.cs
+++ b/WebNovelConverter/Sources/Websites/LNMTLSource.cs
@@ -55,7 +55,13 @@ namespace WebNovelConverter.Sources.Websites
         {
             element.ForAllElements(child =>
             {
-                if(child.NodeName == "W" || child.NodeName == "T")
+                if(child.NodeName == "DQ")
+                {
+                    var newEl = doc.CreateElement("DQ");
+                    newEl.TextContent = child.GetInnerText();
+                    child.ReplaceWith(newEl);
+                }
+                else if(child.NodeName == "W" || child.NodeName == "T")
                 {
                     child.ReplaceWith(doc.CreateTextNode(" " + child.GetInnerText()));
                 }

--- a/WebNovelConverter/Sources/Websites/LNMTLSource.cs
+++ b/WebNovelConverter/Sources/Websites/LNMTLSource.cs
@@ -30,11 +30,15 @@ namespace WebNovelConverter.Sources.Websites
             IElement titleElement = doc.DocumentElement.QuerySelector(".chapter-title");
             IElement chapterElement = doc.DocumentElement.QuerySelector(".chapter-body");
 
+            // Append paragraphs after each "sentence.translated" element.
+            chapterElement
+                .QuerySelectorAll("sentence.translated")
+                .ToList()
+                .ForEach((obj) => obj.AppendChild(doc.CreateElement("P")));
             var contentEl = doc.CreateElement("P");
             contentEl.InnerHtml = string.Join("", chapterElement
                 .QuerySelectorAll("sentence.translated")
                 .Select(x => x.InnerHtml));
-            CreateParagraphs(doc, contentEl);
             RemoveSpecialTags(doc, contentEl);
 
             string nextChapter = doc.QuerySelector("ul.pager > li.next > a")?.GetAttribute("href");
@@ -45,17 +49,6 @@ namespace WebNovelConverter.Sources.Websites
                 Content = new ContentCleanup(BaseUrl).Execute(doc, contentEl),
                 NextChapterUrl = nextChapter
             };
-        }
-
-        private void CreateParagraphs(IDocument doc, IElement element)
-        {
-            foreach (var child in element.ChildNodes.ToList())
-            {
-                if (child.NodeType == NodeType.Element && child.NodeName == "DQ")
-                {
-                    ContentCleanup.ReplaceElementWithParagraph(doc, child);
-                }
-            }
         }
 
         private void RemoveSpecialTags(IDocument doc, IElement element)

--- a/WebNovelConverter/Sources/Websites/LNMTLSource.cs
+++ b/WebNovelConverter/Sources/Websites/LNMTLSource.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Dom.Html;
-using WebNovelConverter.Extensions;
 using WebNovelConverter.Sources.Models;
 using WebNovelConverter.Sources.Helpers;
 


### PR DESCRIPTION
I think it is better when a paragraph is added after each "sentence.translated" element, instead of after each "dq" element.

**Before:**
<img width="459" alt="before" src="https://cloud.githubusercontent.com/assets/7832423/20042434/303d8aba-a47a-11e6-88f6-393553112bad.png">

**After:**
<img width="460" alt="after" src="https://cloud.githubusercontent.com/assets/7832423/20053212/c89dbbba-a4d7-11e6-8e92-e3eaa932de6b.png">